### PR TITLE
feature: health tweaks

### DIFF
--- a/scenes/player/platformer_character_body.tscn
+++ b/scenes/player/platformer_character_body.tscn
@@ -54,6 +54,9 @@ metadata/_custom_type_script = "uid://bsmfg3s82glt1"
 
 [node name="HealthTracker" type="Node" parent="."]
 script = ExtResource("5_21ocv")
+health = 30
+max_health = 30
+last_health_threashold = 1
 death_event = "player_death"
 health_changed_event = "player_health_changed"
 max_health_changed_event = "player_max_health_changed"

--- a/scenes/player/player_nodes.tscn
+++ b/scenes/player/player_nodes.tscn
@@ -15,7 +15,6 @@
 
 [node name="PlayerProjectilePool" parent="LockedTransform" node_paths=PackedStringArray("projectile_source") instance=ExtResource("4_akq3i")]
 projectile_source = NodePath("../../CharacterBody2D")
-player_momentum_percentage = 0.5
 
 [node name="GameUILayer" parent="LockedTransform" instance=ExtResource("1_frhop")]
 
@@ -39,7 +38,7 @@ timer_to_display = NodePath("../HealthPotions/HealUseTimer")
 
 [node name="HealthPotions" type="Node" parent="CharacterBody2D" node_paths=PackedStringArray("entity", "heal_use_timer")]
 script = ExtResource("5_nhxao")
-health_regain_amount = 10.0
+health_regain_amount = 30.0
 entity = NodePath("..")
 heal_use_timer = NodePath("HealUseTimer")
 use_health_potion_input = "use_heal"

--- a/scenes/player/player_projectile_pool.tscn
+++ b/scenes/player/player_projectile_pool.tscn
@@ -13,7 +13,7 @@ launch_action = "shoot"
 projectile = NodePath("Projectile")
 fully_charged_multiplier = 1.5
 projectile_offset = Vector2(0, -10)
-player_momentum_percentage = 0.3
+player_momentum_percentage = 0.5
 max_hold_timer = 0.8
 
 [node name="Projectile" type="ShapeCast2D" parent="." node_paths=PackedStringArray("sprite")]
@@ -25,6 +25,8 @@ script = ExtResource("2_s00wn")
 sprite = NodePath("Sprite2D")
 launch_speed = 300.0
 gravity = 700.0
+damage = 0.0
+damage_per_speed = 0.01
 metadata/_custom_type_script = "uid://dmr8rgopkln6l"
 
 [node name="Sprite2D" type="Sprite2D" parent="Projectile"]

--- a/scenes/ui/ui_layer.tscn
+++ b/scenes/ui/ui_layer.tscn
@@ -15,12 +15,14 @@ offset_bottom = 32.0
 show_percentage = false
 script = ExtResource("1_3eqaf")
 
-[node name="HealthProgressBar" type="ProgressBar" parent="."]
+[node name="HealthProgressBar" type="ProgressBar" parent="." node_paths=PackedStringArray("number_label")]
 offset_left = 80.0
 offset_top = 606.0
 offset_right = 287.0
 offset_bottom = 633.0
+show_percentage = false
 script = ExtResource("2_0d208")
+number_label = NodePath("HealthNumberLabel")
 
 [node name="HealthLabel" type="Label" parent="HealthProgressBar"]
 layout_mode = 0
@@ -28,6 +30,11 @@ offset_left = -67.0
 offset_right = -11.0
 offset_bottom = 23.0
 text = "Health:"
+
+[node name="HealthNumberLabel" type="Label" parent="HealthProgressBar"]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 23.0
 
 [node name="DeathMenu" type="VBoxContainer" parent="."]
 process_mode = 2

--- a/scripts/event_bus.gd
+++ b/scripts/event_bus.gd
@@ -10,10 +10,10 @@ signal player_projectile_charge(max: float, current: float);
 signal player_projectile_launch();
 
 @warning_ignore("unused_signal")
-signal player_health_changed(current: float);
+signal player_health_changed(current: int);
 
 @warning_ignore("unused_signal")
-signal player_max_health_changed(current: float);
+signal player_max_health_changed(current: int);
 
 @warning_ignore("unused_signal")
 signal player_death();

--- a/scripts/health/health_potions.gd
+++ b/scripts/health/health_potions.gd
@@ -14,7 +14,8 @@ func on_enter_checkpoint(checkpoint: Area2D):
 
 func _physics_process(delta: float) -> void:
 	if Input.is_action_just_pressed(self.use_health_potion_input):
-		self.heal_use_timer.start();
+		if self.current_potions > 0:
+			self.heal_use_timer.start();
 	
 	if Input.is_action_just_released(self.use_health_potion_input):
 		self.heal_use_timer.stop();

--- a/scripts/health/health_tracker.gd
+++ b/scripts/health/health_tracker.gd
@@ -1,9 +1,10 @@
 extends Node
 class_name HealthTracker
 
-@export var health: float = 10;
-@export var max_health: float = 10;
-@export var increase_per_second: float = 0;
+@export var health: int = 10;
+@export var max_health: int = 10;
+
+@export var last_health_threashold: int = 3;
 var dead: bool = false;
 
 @export_category("event bus signals")
@@ -11,20 +12,20 @@ var dead: bool = false;
 @export var health_changed_event: String = "";
 @export var max_health_changed_event: String = "";
 
-signal health_changed(current:float);
-signal max_health_changed(current: float);
+signal health_changed(current:int);
+signal max_health_changed(current: int);
 signal death();
 
 func _ready() -> void:
 	self.on_max_health_change();
 	self.on_health_change();
 
-func _physics_process(delta: float) -> void:
-	self.change_health(self.increase_per_second * delta);
-
 ## use this function to change the health of the entity.
-func change_health(amount: float):
-	self.health += amount;
+func change_health(amount: int):
+	if self.health > self.last_health_threashold && (self.health + amount) <= 0:
+		self.health = 1.;
+	else:
+		self.health += amount;
 	if self.health > self.max_health:
 		self.health = self.max_health;
 	
@@ -54,7 +55,7 @@ func on_max_health_change():
 	if self.max_health_changed_event != "":
 		EventBus.emit_signal(self.max_health_changed_event, self.max_health);
 
-func add_max_health(amount: float):
+func add_max_health(amount: int):
 	self.health += amount;
 	self.max_health += amount;
 	self.on_max_health_change();

--- a/scripts/ui/player_health_progress_bar.gd
+++ b/scripts/ui/player_health_progress_bar.gd
@@ -1,11 +1,14 @@
 extends ProgressBar
 
+@export var number_label: Label;
+
 func _ready() -> void:
 	EventBus.player_health_changed.connect(self.on_health_changed);
 	EventBus.player_max_health_changed.connect(self.on_max_health_changed);
 
-func on_health_changed(current: float):
+func on_health_changed(current: int):
 	self.value = current;
+	self.number_label.text = String.num_int64(current);
 
-func on_max_health_changed(current: float):
+func on_max_health_changed(current: int):
 	self.max_value = current;


### PR DESCRIPTION
tweaked health to be stored as int, no partial health

player will not die from a single hit, as that will reduce health down to last health threashold as long as player isn't already there.

projectile damage scales only off of speed and not base damage.

-fix: health potion still usable when out of potions